### PR TITLE
Into options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl<'src> SourceCache<'src> {
 /// `driver_options` for itself, and `options` for the tool.
 ///
 /// Fields are public so that they are constructable by the caller.
-pub struct Driver<X, TArgs, DArgs, D: DriverSelector + Args = DefaultDriver>
+pub struct Driver<X, DArgs, TArgs, D: DriverSelector + Args = DefaultDriver>
 where
     X: Tool,
     DArgs: Into<Params<D::RequiredArgs, D::OptionalArgs>>,
@@ -114,11 +114,11 @@ where
     pub tool_args: TArgs,
 }
 
-impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, DefaultDriver>
+impl<X, DArgs, TArgs> Driver<X, DArgs, TArgs, DefaultDriver>
 where
     X: Tool,
-    DOpts: Into<Params<DriverArgs, DriverOptionalArgs>>,
-    TOpts: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
+    DArgs: Into<Params<DriverArgs, DriverOptionalArgs>>,
+    TArgs: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
     // This bound is not needed, but perhaps informative.
     DefaultDriver:
         DriverSelector + Args<RequiredArgs = DriverArgs, OptionalArgs = DriverOptionalArgs>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,17 +105,13 @@ where
 {
     /// This is mostly here to guide inference, and generally would be a unitary type.
     pub tool: X,
+    /// This is here to guide inference, and allow for future expansion, in the case
+    /// that we require a different driver implementation, or changes to driver_args.
     pub driver: D,
-    /// Options which are specific to the driver and kept hidden
-    /// from the tool. For instance whether warnings are errors.
-    /// Since `tools` route errors through the driver, tools should
-    /// not concern themselves with it.
-    ///
-    /// Similarly if we implement `Path`/source providing in the driver.
-    /// Tools should also probably not concern themselves with that.
-    pub driver_options: DArgs,
-    // Can this be Into<...>?
-    pub options: TArgs,
+    /// Options that get handled by the driver.
+    pub driver_args: DArgs,
+    // Options specific to a `Tool`.
+    pub tool_args: TArgs,
 }
 
 /// Errors occurred by the driver.
@@ -163,7 +159,7 @@ where
         diagnostics: &mut D,
         source_cache: &mut HashMap<SourceId, (path::PathBuf, String)>,
     ) -> Result<X::Output, DriverError> {
-        let mut driver_options = self.driver_options.into();
+        let mut driver_options = self.driver_args.into();
         let mut source_ids = Vec::new();
         if let Some(source_path) = driver_options.optional.source_path.take() {
             let dir = cap_std::fs::Dir::open_ambient_dir(
@@ -193,7 +189,7 @@ where
         let emitter = DiagnosticsEmitter::new(self.tool, diagnostics);
         let session = Session { source_ids };
         Ok(X::Output::tool_init(
-            self.options.into(),
+            self.tool_args.into(),
             source_cache,
             emitter,
             session,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,33 +114,6 @@ where
     pub tool_args: TArgs,
 }
 
-/// Errors occurred by the driver.
-#[derive(thiserror::Error, Debug)]
-pub enum DriverError {
-    #[error("Io error {0} ")]
-    Io(#[from] io::Error),
-}
-
-static LAST_SOURCE_ID: AtomicUsize = AtomicUsize::new(0);
-
-pub struct Session {
-    source_ids: Vec<SourceId>,
-}
-
-/// A session is created during `driver_init`, and contains
-/// `SourceId`s for the documents loaded during driver init.
-///
-/// While `source_cache`, and `diagnostics` are allowed to
-/// persist across driver runs. `Session` is ephemeral.
-///
-/// This can be used to obtain the subset of the files asked to
-/// be loaded from the `source_cache`.
-impl Session {
-    pub fn source_ids(&self) -> impl Iterator<Item = SourceId> + '_ {
-        self.source_ids.iter().copied()
-    }
-}
-
 impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, DefaultDriver>
 where
     X: Tool,
@@ -194,6 +167,32 @@ where
             emitter,
             session,
         ))
+    }
+}
+/// Errors occurred by the driver.
+#[derive(thiserror::Error, Debug)]
+pub enum DriverError {
+    #[error("Io error {0} ")]
+    Io(#[from] io::Error),
+}
+
+static LAST_SOURCE_ID: AtomicUsize = AtomicUsize::new(0);
+
+pub struct Session {
+    source_ids: Vec<SourceId>,
+}
+
+/// A session is created during `driver_init`, and contains
+/// `SourceId`s for the documents loaded during driver init.
+///
+/// While `source_cache`, and `diagnostics` are allowed to
+/// persist across driver runs. `Session` is ephemeral.
+///
+/// This can be used to obtain the subset of the files asked to
+/// be loaded from the `source_cache`.
+impl Session {
+    pub fn source_ids(&self) -> impl Iterator<Item = SourceId> + '_ {
+        self.source_ids.iter().copied()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ where
 }
 
 pub trait Args {
-    /// A tool specific type for arguments must be given.
+    /// A tool specific type for arguments that must be given.
     type RequiredArgs;
     /// A tool specific type for arguments which derive `Default`
     type OptionalArgs: Default;
@@ -44,7 +44,7 @@ where
     X: Tool,
 {
     fn tool_init<D: Diagnostics<X>>(
-        config: Options<X::RequiredArgs, X::OptionalArgs>,
+        config: Params<X::RequiredArgs, X::OptionalArgs>,
         source_cache: SourceCache<'_>,
         emitter: DiagnosticsEmitter<X, D>,
         session: Session,
@@ -100,8 +100,8 @@ impl<'src> SourceCache<'src> {
 pub struct Driver<X, TArgs, DArgs, D: DriverSelector + Args = DefaultDriver>
 where
     X: Tool,
-    DArgs: Into<Options<D::RequiredArgs, D::OptionalArgs>>,
-    TArgs: Into<Options<X::RequiredArgs, X::OptionalArgs>>,
+    DArgs: Into<Params<D::RequiredArgs, D::OptionalArgs>>,
+    TArgs: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
 {
     /// This is mostly here to guide inference, and generally would be a unitary type.
     pub tool: X,
@@ -144,8 +144,8 @@ impl Session {
 impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, DefaultDriver>
 where
     X: Tool,
-    DOpts: Into<Options<DriverArgs, DriverOptionalArgs>>,
-    TOpts: Into<Options<X::RequiredArgs, X::OptionalArgs>>,
+    DOpts: Into<Params<DriverArgs, DriverOptionalArgs>>,
+    TOpts: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
     // This bound is not needed, but perhaps informative.
     DefaultDriver:
         DriverSelector + Args<RequiredArgs = DriverArgs, OptionalArgs = DriverOptionalArgs>,
@@ -251,7 +251,7 @@ pub struct DriverArgs {
 }
 
 #[derive(Default)]
-/// Optional arguments common to all drivers.
+/// Optional arguments common to a driver.
 pub struct DriverOptionalArgs {
     /// Reads a source at the given `path` relative to the
     /// `relative_to_path` argument.
@@ -362,13 +362,13 @@ pub trait Diagnostics<X: Tool> {
     fn no_more_data(&mut self);
 }
 
-/// A pair of required and optional fields.
-pub struct Options<Required, Optional> {
+/// A pair of required and optional parameters.
+pub struct Params<Required, Optional> {
     pub required: Required,
     pub optional: Optional,
 }
 
-impl<Required, Optional> From<(Required, Optional)> for Options<Required, Optional> {
+impl<Required, Optional> From<(Required, Optional)> for Params<Required, Optional> {
     fn from((required, optional): (Required, Optional)) -> Self {
         Self { required, optional }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -169,8 +169,7 @@ mod tests {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
-                )
-                    .into(),
+                ),
                 options: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
@@ -205,8 +204,7 @@ mod tests {
                         source_path: Some("Cargo.toml".into()),
                         ..Default::default()
                     },
-                )
-                    .into(),
+                ),
                 options: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
@@ -241,9 +239,10 @@ mod tests {
         //
         // So in addition to changing the `DriverArgsSelection`,
         // they can differ in their initialization as well.
-        impl<X: Tool, TOpts> Driver<X, TOpts, ()>
+        impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, ()>
         where
             X: Tool,
+            DOpts: Into<Options<(), bool>>,
             TOpts: Into<Options<X::RequiredArgs, X::OptionalArgs>>,
         {
             pub fn driver_init<D: Diagnostics<X>>(
@@ -252,6 +251,7 @@ mod tests {
                 diagnostics: &mut D,
                 _extra_param: (),
             ) -> Result<X::Output, DriverError> {
+                let _driver_opts: Options<(), bool> = self.driver_options.into();
                 let emitter = DiagnosticsEmitter::new(self.tool, diagnostics);
                 let source_cache = SourceCache { source_cache };
                 let session = Session { source_ids: vec![] };
@@ -269,7 +269,7 @@ mod tests {
             let driver = Driver {
                 tool: Yacc,
                 driver: (),
-                driver_options: ((), true).into(),
+                driver_options: ((), true),
                 options: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
@@ -380,7 +380,7 @@ mod tests {
             let driver = Driver {
                 tool: Lex,
                 driver: (),
-                driver_options: ((), true).into(),
+                driver_options: ((), true),
                 options: ((), ()),
             }
             .driver_init(&mut source_cache, &mut diagnostics, ())
@@ -404,8 +404,7 @@ mod tests {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
-                )
-                    .into(),
+                ),
                 options: ((), ()),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
@@ -426,8 +425,7 @@ mod tests {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
-                )
-                    .into(),
+                ),
                 options: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,

--- a/src/test.rs
+++ b/src/test.rs
@@ -165,14 +165,14 @@ mod tests {
             let driver = Driver {
                 driver: DefaultDriver,
                 tool: Yacc,
-                driver_options: (
+                driver_args: (
                     DriverArgs {},
                     DriverOptionalArgs {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
                 ),
-                options: (
+                tool_args: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
                     },
@@ -200,14 +200,14 @@ mod tests {
             let driver = Driver {
                 tool: Yacc,
                 driver: DefaultDriver,
-                driver_options: (
+                driver_args: (
                     DriverArgs {},
                     DriverOptionalArgs {
                         source_path: Some("Cargo.toml".into()),
                         ..Default::default()
                     },
                 ),
-                options: (
+                tool_args: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
                     },
@@ -254,12 +254,12 @@ mod tests {
                 diagnostics: &mut D,
                 _extra_param: (),
             ) -> Result<X::Output, DriverError> {
-                let _driver_opts: Options<(), bool> = self.driver_options.into();
+                let _driver_opts: Options<(), bool> = self.driver_args.into();
                 let emitter = DiagnosticsEmitter::new(self.tool, diagnostics);
                 let source_cache = SourceCache { source_cache };
                 let session = Session { source_ids: vec![] };
                 Ok(X::Output::tool_init(
-                    self.options.into(),
+                    self.tool_args.into(),
                     source_cache,
                     emitter,
                     session,
@@ -272,8 +272,8 @@ mod tests {
             let driver = Driver {
                 tool: Yacc,
                 driver: (),
-                driver_options: ((), true),
-                options: (
+                driver_args: ((), true),
+                tool_args: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
                     },
@@ -384,8 +384,8 @@ mod tests {
             let driver = Driver {
                 tool: Lex,
                 driver: (),
-                driver_options: ((), true),
-                options: ((), ()),
+                driver_args: ((), true),
+                tool_args: ((), ()),
             }
             .driver_init(&mut source_cache, &mut diagnostics, ())
             .unwrap();
@@ -402,14 +402,14 @@ mod tests {
             let driver = Driver {
                 tool: Lex,
                 driver: DefaultDriver,
-                driver_options: (
+                driver_args: (
                     DriverArgs {},
                     DriverOptionalArgs {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
                 ),
-                options: ((), ()),
+                tool_args: ((), ()),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
             .unwrap();
@@ -423,14 +423,14 @@ mod tests {
             let driver = Driver {
                 tool: Yacc,
                 driver: DefaultDriver,
-                driver_options: (
+                driver_args: (
                     DriverArgs {},
                     DriverOptionalArgs {
                         source_path: Some("Cargo.lock".into()),
                         ..Default::default()
                     },
                 ),
-                options: (
+                tool_args: (
                     YaccArgs {
                         yacc_kind: YaccKind::Grmtools,
                     },

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ mod tests {
         type Error = YaccGrammarError;
         type Warning = YaccGrammarWarning;
         type OptionalArgs = YaccGrammarOptArgs;
-        type RequiredArgs<'a> = YaccArgs;
+        type RequiredArgs = YaccArgs;
         type Output = GrammarASTWithValidationCertificate;
     }
 
@@ -126,9 +126,9 @@ mod tests {
         }
     }
 
-    impl<'args> ToolInit<'args, Yacc> for GrammarASTWithValidationCertificate {
+    impl ToolInit<Yacc> for GrammarASTWithValidationCertificate {
         fn tool_init<R: Diagnostics<Yacc>>(
-            options: Options<<Yacc as Tool>::RequiredArgs<'args>, <Yacc as Tool>::OptionalArgs>,
+            options: Options<<Yacc as Tool>::RequiredArgs, <Yacc as Tool>::OptionalArgs>,
             source_cache: SourceCache<'_>,
             mut emitter: DiagnosticsEmitter<Yacc, R>,
             session: Session,
@@ -243,7 +243,7 @@ mod tests {
         //
         // So in addition to changing the `DriverArgsSelection`,
         // they can differ in their initialization as well.
-        impl<X: Tool> Driver<'_, X, ()> {
+        impl<X: Tool> Driver<X, ()> {
             pub fn driver_init<D: Diagnostics<X>>(
                 self,
                 source_cache: &mut HashMap<SourceId, (path::PathBuf, String)>,
@@ -347,7 +347,7 @@ mod tests {
 
     struct LexOutput {}
 
-    impl<'args> ToolInit<'args, Lex> for LexOutput {
+    impl ToolInit<Lex> for LexOutput {
         fn tool_init<'diag, 'src, D: Diagnostics<Lex>>(
             _config: Options<(), ()>,
             _source_cache: SourceCache<'_>,
@@ -365,7 +365,7 @@ mod tests {
         // This is mostly a test that we can populate the same source_cache
         // from multiple tools.
         type OptionalArgs = ();
-        type RequiredArgs<'a> = ();
+        type RequiredArgs = ();
         type Output = LexOutput;
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -242,11 +242,11 @@ mod tests {
         //
         // So in addition to changing the `DriverArgsSelection`,
         // they can differ in their initialization as well.
-        impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, ()>
+        impl<X, DArgs, TArgs> Driver<X, DArgs, TArgs, ()>
         where
             X: Tool,
-            DOpts: Into<Params<(), bool>>,
-            TOpts: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
+            DArgs: Into<Params<(), bool>>,
+            TArgs: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
         {
             pub fn driver_init<D: Diagnostics<X>>(
                 self,
@@ -254,7 +254,7 @@ mod tests {
                 diagnostics: &mut D,
                 _extra_param: (),
             ) -> Result<X::Output, DriverError> {
-                let _driver_opts: Params<(), bool> = self.driver_args.into();
+                let _driver_args: Params<(), bool> = self.driver_args.into();
                 let emitter = DiagnosticsEmitter::new(self.tool, diagnostics);
                 let source_cache = SourceCache { source_cache };
                 let session = Session { source_ids: vec![] };

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,9 +10,11 @@ mod tests {
     impl Tool for Yacc {
         type Error = YaccGrammarError;
         type Warning = YaccGrammarWarning;
+        type Output = GrammarASTWithValidationCertificate;
+    }
+    impl Args for Yacc {
         type OptionalArgs = YaccGrammarOptArgs;
         type RequiredArgs = YaccArgs;
-        type Output = GrammarASTWithValidationCertificate;
     }
 
     #[derive(Debug)]
@@ -128,7 +130,7 @@ mod tests {
 
     impl ToolInit<Yacc> for GrammarASTWithValidationCertificate {
         fn tool_init<R: Diagnostics<Yacc>>(
-            options: Options<<Yacc as Tool>::RequiredArgs, <Yacc as Tool>::OptionalArgs>,
+            options: Options<<Yacc as Args>::RequiredArgs, <Yacc as Args>::OptionalArgs>,
             source_cache: SourceCache<'_>,
             mut emitter: DiagnosticsEmitter<Yacc, R>,
             session: Session,
@@ -224,7 +226,8 @@ mod tests {
     #[test]
     fn unit_driver() {
         impl _unstable_api_::InternalTrait for () {}
-        impl DriverArgsSelection for () {
+        impl DriverSelector for () {}
+        impl Args for () {
             type RequiredArgs = ();
             type OptionalArgs = bool;
         }
@@ -362,12 +365,13 @@ mod tests {
     impl Tool for Lex {
         type Error = LexError;
         type Warning = NeverWarnings;
-        // FIXME look at lex to figure out what all the below should be,
-        // This is mostly a test that we can populate the same source_cache
-        // from multiple tools.
+        // FIXME look at what lex returns.
+        type Output = LexOutput;
+    }
+    impl Args for Lex {
+        // FIXME look at lex args.
         type OptionalArgs = ();
         type RequiredArgs = ();
-        type Output = LexOutput;
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -176,8 +176,7 @@ mod tests {
                         yacc_kind: YaccKind::Grmtools,
                     },
                     Default::default(),
-                )
-                    .into(),
+                ),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
             .unwrap();
@@ -213,8 +212,7 @@ mod tests {
                         yacc_kind: YaccKind::Grmtools,
                     },
                     Default::default(),
-                )
-                    .into(),
+                ),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
             .unwrap();
@@ -243,7 +241,11 @@ mod tests {
         //
         // So in addition to changing the `DriverArgsSelection`,
         // they can differ in their initialization as well.
-        impl<X: Tool> Driver<X, ()> {
+        impl<X: Tool, TOpts> Driver<X, TOpts, ()>
+        where
+            X: Tool,
+            TOpts: Into<Options<X::RequiredArgs, X::OptionalArgs>>,
+        {
             pub fn driver_init<D: Diagnostics<X>>(
                 self,
                 source_cache: &mut HashMap<SourceId, (path::PathBuf, String)>,
@@ -254,7 +256,7 @@ mod tests {
                 let source_cache = SourceCache { source_cache };
                 let session = Session { source_ids: vec![] };
                 Ok(X::Output::tool_init(
-                    self.options,
+                    self.options.into(),
                     source_cache,
                     emitter,
                     session,
@@ -273,8 +275,7 @@ mod tests {
                         yacc_kind: YaccKind::Grmtools,
                     },
                     Default::default(),
-                )
-                    .into(),
+                ),
             }
             .driver_init(&mut source_cache, &mut diagnostics, ())
             .unwrap();
@@ -380,7 +381,7 @@ mod tests {
                 tool: Lex,
                 driver: (),
                 driver_options: ((), true).into(),
-                options: ((), ()).into(),
+                options: ((), ()),
             }
             .driver_init(&mut source_cache, &mut diagnostics, ())
             .unwrap();
@@ -405,7 +406,7 @@ mod tests {
                     },
                 )
                     .into(),
-                options: ((), ()).into(),
+                options: ((), ()),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
             .unwrap();
@@ -432,8 +433,7 @@ mod tests {
                         yacc_kind: YaccKind::Grmtools,
                     },
                     Default::default(),
-                )
-                    .into(),
+                ),
             }
             .driver_init(&mut diagnostics, &mut source_cache)
             .unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -130,7 +130,7 @@ mod tests {
 
     impl ToolInit<Yacc> for GrammarASTWithValidationCertificate {
         fn tool_init<R: Diagnostics<Yacc>>(
-            options: Options<<Yacc as Args>::RequiredArgs, <Yacc as Args>::OptionalArgs>,
+            options: Params<<Yacc as Args>::RequiredArgs, <Yacc as Args>::OptionalArgs>,
             source_cache: SourceCache<'_>,
             mut emitter: DiagnosticsEmitter<Yacc, R>,
             session: Session,
@@ -245,8 +245,8 @@ mod tests {
         impl<X, TOpts, DOpts> Driver<X, TOpts, DOpts, ()>
         where
             X: Tool,
-            DOpts: Into<Options<(), bool>>,
-            TOpts: Into<Options<X::RequiredArgs, X::OptionalArgs>>,
+            DOpts: Into<Params<(), bool>>,
+            TOpts: Into<Params<X::RequiredArgs, X::OptionalArgs>>,
         {
             pub fn driver_init<D: Diagnostics<X>>(
                 self,
@@ -254,7 +254,7 @@ mod tests {
                 diagnostics: &mut D,
                 _extra_param: (),
             ) -> Result<X::Output, DriverError> {
-                let _driver_opts: Options<(), bool> = self.driver_args.into();
+                let _driver_opts: Params<(), bool> = self.driver_args.into();
                 let emitter = DiagnosticsEmitter::new(self.tool, diagnostics);
                 let source_cache = SourceCache { source_cache };
                 let session = Session { source_ids: vec![] };
@@ -353,7 +353,7 @@ mod tests {
 
     impl ToolInit<Lex> for LexOutput {
         fn tool_init<'diag, 'src, D: Diagnostics<Lex>>(
-            _config: Options<(), ()>,
+            _config: Params<(), ()>,
             _source_cache: SourceCache<'_>,
             _emitter: DiagnosticsEmitter<Lex, D>,
             _session: Session,


### PR DESCRIPTION
This branch converts some things to use the `Into<Options<Required, Optional>>`, to move the `into()` calls out call-sites
and into `driver_init`.   Doing so however entailed dropping a lifetime on a GAT (turning it into just an associated type).

This lifetime was no longer used for anything since I made driver have source caches, and options for loading files from strings.
`Tool`, no longer has to pass a reference to a string, for both the tool and the caller to have it.  But I think that it makes it impossible to implement `Tool` for a type with options that require a lifetime after this change.

This makes the `driver_init` impl a little uglier, but I think the `.into()` calls are a real eyesore, and it should be rare that we implement `driver_init`.

I guess I should have another go at trying to implement it *with* the lifetime, but my attempts were leading to a unconstrained lifetime parameter.